### PR TITLE
Change onmousewheel to onwheel, fixes #59

### DIFF
--- a/Diagram/Diagram.razor
+++ b/Diagram/Diagram.razor
@@ -17,8 +17,8 @@
          @onmousemove:preventDefault
          @onmousedown="OnMouseDown"
          @onmouseup="OnMouseUp"
-         @onmousewheel="OnMouseWheel"
-         @onmousewheel:preventDefault>
+         @onwheel="OnMouseWheel"
+         @onwheel:preventDefault>
         <CascadingValue Value="@this" IsFixed="true">
             @using (var temporary_culture2 = new CultureSwapper())
             {


### PR DESCRIPTION
onmousewheel is non-standard and deprecated

https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onmousewheel 
>Do not use this wheel event. This interface is non-standard and deprecated. It was used in non-Gecko browsers only. Instead use the standard wheel event.